### PR TITLE
Fix disk space issue caused due to mongo logrotate and selinux alerts…

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -54,6 +54,7 @@ mongodb_semodule_install: false
 mongodb_semodule_file_type_enforcement_dest: /etc/selinux/te
 mongodb_semodule_te_items:
   - sshd_mongod_port_forward_allow.te
+  - my-ftdc.te  
 
 
 

--- a/files/my-ftdc.te
+++ b/files/my-ftdc.te
@@ -1,0 +1,11 @@
+# Allow /usr/bin/mongod read access on the file /proc/net/snmp
+module my-ftdc 1.0;
+
+require {
+	type proc_net_t;
+	type mongod_t;
+	class file read;
+}
+
+#============= mongod_t ==============
+allow mongod_t proc_net_t:file read;

--- a/templates/logrotate.j2
+++ b/templates/logrotate.j2
@@ -9,5 +9,6 @@
     sharedscripts
     postrotate
         /bin/kill -SIGUSR1 `cat {{ mongodb_data_dir }}/mongod.lock 2> /dev/null` 2> /dev/null || true
+        /bin/kill -SIGUSR1 `cat /var/run/mongodb/mongod.pid 2> /dev/null` 2> /dev/null || true
     endscript
 }


### PR DESCRIPTION
… for audit logs

Disk space issue caused by Mongo logrotate
Everytime logrotae runs on mongo logs, the deleted log file is still left open which causes disk space issues with mongo. 
I have added updated the post rotate script to fix this

Audit logs
After we upgraded to Mongo 3.6.21 we started seeing sealerts.
Added my-ftdc.te to fix the selinux alerts which grants mongo read access /proc/net/snmp